### PR TITLE
Fix text color mappings

### DIFF
--- a/ui-framework/theme/colors.ts
+++ b/ui-framework/theme/colors.ts
@@ -5,9 +5,9 @@ export const textColorClass = {
   accent: 'text-[#1E3A8A]',          // Navy Blue – bold and trustworthy
   neutral: 'text-[#374151]',         // Neutral base
   dark: 'text-[#111827]',            
-  red: 'bg-red-700',
-  blue: 'bg-blue-700',
-  white: 'bg-white',
+  red: 'text-red-700',
+  blue: 'text-blue-700',
+  white: 'text-white',
   success: 'text-green-600',
   danger: 'text-red-600',
 };


### PR DESCRIPTION
## Summary
- fix class names in `textColorClass` for red/blue/white

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_685242da33ac832aa35e1006fae65ae6