### PR TITLE
Fix gap class syntax

### DIFF
--- a/ui-framework/theme/gap.ts
+++ b/ui-framework/theme/gap.ts
@@ -10,7 +10,7 @@ export const gapClass = {
   "4xl": "gap-20",
   "5xl": "gap-24",
   "6xl": "gap-32",
-  primary: "gap-1 sm:gap-2, md:gap-3 lg:gap-4"
+  primary: "gap-1 sm:gap-2 md:gap-3 lg:gap-4"
 };
 
 


### PR DESCRIPTION
## Summary
- remove comma from gap class definition

## Testing
- `npm run build`
- `npm run lint` *(fails: couldn't find ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6852435c6c4c832a94828f312edbab99