### PR TITLE
Fix secondary padding class

### DIFF
--- a/ui-framework/theme/padding.ts
+++ b/ui-framework/theme/padding.ts
@@ -11,7 +11,7 @@ export const paddingClass = {
   "5xl": "p-24",
   "6xl": "p-32",
   primary: "p-4 sm:p-8 md:p-12 lg:p-16",
-  secondary: "p-4 sm:p-10 md:p-16 lg:p20",
+  secondary: "p-4 sm:p-10 md:p-16 lg:p-20",
 };
 
 export const paddingTopClass = {


### PR DESCRIPTION
## Summary
- correct `lg:p20` typo in secondary padding class

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_685243725b58832a835f10542ff2d973