### PR TITLE
Fix modal scroll restore

### DIFF
--- a/ui-framework/components/modal/Modal.tsx
+++ b/ui-framework/components/modal/Modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import clsx from "clsx";
 import {
@@ -25,9 +25,18 @@ const Modal: React.FC<ModalProps> = ({
   children,
   className = "",
 }) => {
+  const originalOverflow = useRef<string>(document.body.style.overflow);
+
   // Disable background scroll when modal is open
   useEffect(() => {
-    document.body.style.overflow = isOpen ? "hidden" : "";
+    if (isOpen) {
+      originalOverflow.current = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      document.body.style.overflow = originalOverflow.current;
+    };
   }, [isOpen]);
 
   if (!isOpen) return null;


### PR DESCRIPTION
## Summary
- preserve the existing `document.body.style.overflow` before hiding scroll in `Modal`
- restore the previous overflow style when the modal unmounts or closes

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_685243b3facc832aa5414447e0560022